### PR TITLE
Specify supported python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,7 @@ To install PyCupid just run:
 ```
 pip install pycupid
 ```
+Wheels for PyCupid are only available for python 2.7, 3.4, 3.5 and 3.6. Installation on newer version (3.7, 3.8) [fails](https://github.com/ChileanVirtualObservatory/pycupid/issues/16#issue-503170953)!  
+Create a virtual environment with an older python version if necessary.
 
 For developers we have a wiki to compile pycupid in [*Manylinux*](https://github.com/ChileanVirtualObservatory/pycupid/wiki)

--- a/setup.py
+++ b/setup.py
@@ -163,4 +163,5 @@ setup(
     install_requires = {
         'numpy >= 1.11.2',
     },
+    python_requires='==2.7.*, ==3.4.*, ==3.5.*, ==3.6.*'
 )


### PR DESCRIPTION

Fixes #16 by preventing installation on unsupported python versions.
Also mention supported version in Readme.